### PR TITLE
bump platform_tools to 33.0.3

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -2,7 +2,7 @@
 
 FASTBOOT=platform-tools/fastboot
 
-VERSION="r28.0.2"
+VERSION="r33.0.3"
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 if [ ! -f $FASTBOOT ]; then


### PR DESCRIPTION
on an apple silicon the fastboot binary was incorrect architecture.

here google publishes the latest version + changelog:

https://developer.android.com/studio/releases/platform-tools

we can see that "universal binaries" were implemented in v32.0.0

<img width="744" alt="Screenshot 2022-11-08 at 11 24 21 PM" src="https://user-images.githubusercontent.com/175305/200765282-be5a38a8-4e73-4fee-837e-a52e1050c23b.png">


tested this and it was executing fine, however the changelog makes it seem wise to go to the latest version.

successfully flashed my comma 3 using this version on an M1 Mac Mini on Ventura